### PR TITLE
Feature: Allow consumers to start from a specified offset

### DIFF
--- a/src/KafkaFlow.Abstractions/Configuration/IConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IConsumerConfigurationBuilder.cs
@@ -31,6 +31,14 @@ public interface IConsumerConfigurationBuilder
     IConsumerConfigurationBuilder ManualAssignPartitions(string topicName, IEnumerable<int> partitions);
 
     /// <summary>
+    /// Explicitly defines the topic, partitions and offsets that will be used to read the messages
+    /// </summary>
+    /// <param name="topicName">Topic name</param>
+    /// <param name="partitionOffsets">The partition offset dictionary [Partition ID, Offset]</param>
+    /// <returns></returns>
+    IConsumerConfigurationBuilder ManualAssignPartitionOffsets(string topicName, IDictionary<int, long> partitionOffsets);
+
+    /// <summary>
     /// Sets the topics that will be used to read the messages, the partitions will be automatically assigned
     /// </summary>
     /// <param name="topicNames">Topic names</param>

--- a/src/KafkaFlow.Abstractions/Configuration/SaslOauthbearerMethod.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/SaslOauthbearerMethod.cs
@@ -1,12 +1,11 @@
-﻿namespace KafkaFlow.Configuration
-{
-    /// <summary>SaslOauthbearerMethod enum values</summary>
-    public enum SaslOauthbearerMethod
-    {
-        /// <summary>Default</summary>
-        Default,
+﻿namespace KafkaFlow.Configuration;
 
-        /// <summary>Oidc</summary>
-        Oidc,
-    }
+/// <summary>SaslOauthbearerMethod enum values</summary>
+public enum SaslOauthbearerMethod
+{
+    /// <summary>Default</summary>
+    Default,
+
+    /// <summary>Oidc</summary>
+    Oidc,
 }

--- a/src/KafkaFlow.Abstractions/Configuration/TopicPartitionOffsets.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/TopicPartitionOffsets.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace KafkaFlow.Configuration;
+
+public class TopicPartitionOffsets
+{
+    public TopicPartitionOffsets(string name, IDictionary<int, long> partitionOffsets)
+    {
+        this.Name = name;
+        this.PartitionOffsets = partitionOffsets;
+    }
+
+    public string Name { get; }
+
+    public IDictionary<int, long> PartitionOffsets { get; }
+}

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -12,6 +12,7 @@ internal class ConsumerConfiguration : IConsumerConfiguration
         Confluent.Kafka.ConsumerConfig consumerConfig,
         IReadOnlyList<string> topics,
         IReadOnlyList<TopicPartitions> manualAssignPartitions,
+        IReadOnlyList<TopicPartitionOffsets> manualAssignPartitionOffsets,
         string consumerName,
         ClusterConfiguration clusterConfiguration,
         bool managementDisabled,
@@ -48,6 +49,7 @@ internal class ConsumerConfiguration : IConsumerConfiguration
         this.AutoCommitInterval = autoCommitInterval;
         this.Topics = topics ?? throw new ArgumentNullException(nameof(topics));
         this.ManualAssignPartitions = manualAssignPartitions ?? throw new ArgumentNullException(nameof(manualAssignPartitions));
+        this.ManualAssignPartitionOffsets = manualAssignPartitionOffsets ?? throw new ArgumentNullException(nameof(manualAssignPartitionOffsets));
         this.ConsumerName = consumerName ?? Guid.NewGuid().ToString();
         this.ClusterConfiguration = clusterConfiguration;
         this.ManagementDisabled = managementDisabled;
@@ -75,6 +77,8 @@ internal class ConsumerConfiguration : IConsumerConfiguration
     public IReadOnlyList<string> Topics { get; }
 
     public IReadOnlyList<TopicPartitions> ManualAssignPartitions { get; }
+
+    public IReadOnlyList<TopicPartitionOffsets> ManualAssignPartitionOffsets { get; }
 
     public string ConsumerName { get; }
 

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -11,6 +11,7 @@ internal sealed class ConsumerConfigurationBuilder : IConsumerConfigurationBuild
 {
     private readonly List<string> _topics = new();
     private readonly List<TopicPartitions> _topicsPartitions = new();
+    private readonly List<TopicPartitionOffsets> _topicsPartitionOffsets = new();
     private readonly List<Action<string>> _statisticsHandlers = new();
 
     private readonly List<PendingOffsetsStatisticsHandler> _pendingOffsetsStatisticsHandlers = new();
@@ -57,6 +58,12 @@ internal sealed class ConsumerConfigurationBuilder : IConsumerConfigurationBuild
     public IConsumerConfigurationBuilder ManualAssignPartitions(string topicName, IEnumerable<int> partitions)
     {
         _topicsPartitions.Add(new TopicPartitions(topicName, partitions));
+        return this;
+    }
+
+    public IConsumerConfigurationBuilder ManualAssignPartitionOffsets(string topicName, IDictionary<int, long> partitionOffsets)
+    {
+        _topicsPartitionOffsets.Add(new TopicPartitionOffsets(topicName, partitionOffsets));
         return this;
     }
 
@@ -259,6 +266,7 @@ internal sealed class ConsumerConfigurationBuilder : IConsumerConfigurationBuild
             consumerConfigCopy,
             _topics,
             _topicsPartitions,
+            _topicsPartitionOffsets,
             _name,
             clusterConfiguration,
             _disableManagement,

--- a/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
@@ -30,6 +30,11 @@ public interface IConsumerConfiguration
     IReadOnlyList<TopicPartitions> ManualAssignPartitions { get; }
 
     /// <summary>
+    /// Gets the topic partition offsets to manually assign
+    /// </summary>
+    IReadOnlyList<TopicPartitionOffsets> ManualAssignPartitionOffsets { get; }
+
+    /// <summary>
     /// Gets the consumer name
     /// </summary>
     string ConsumerName { get; }

--- a/tests/KafkaFlow.IntegrationTests/ConsumerTest.cs
+++ b/tests/KafkaFlow.IntegrationTests/ConsumerTest.cs
@@ -183,11 +183,15 @@ public class ConsumerTest
         MessageStorage.Clear();
         
         // Act
-        var serviceProvider = await new ServiceProviderHelper().GetServiceProviderAsync(
+        var serviceProviderHelper = new ServiceProviderHelper();
+        
+        await serviceProviderHelper.GetServiceProviderAsync(
             consumerConfig =>
             {
                 consumerConfig.ManualAssignPartitionOffsets(Bootstrapper.OffsetTrackerTopicName, new Dictionary<int, long> { { 0, endOffset - 4 } })
                     .WithGroupId("ManualAssignPartitionOffsetsTest")
+                    .WithBufferSize(100)
+                    .WithWorkersCount(10)
                     .AddMiddlewares(
                         middlewares => middlewares
                             .AddDeserializer<JsonCoreDeserializer>()
@@ -205,8 +209,8 @@ public class ConsumerTest
         {
             await MessageStorage.AssertOffsetTrackerMessageAsync(messages[i]);
         }
-        
-        await serviceProvider.CreateKafkaBus().StopAsync();
+
+        await serviceProviderHelper.StopBusAsync();
         
         return;
         

--- a/tests/KafkaFlow.IntegrationTests/ConsumerTest.cs
+++ b/tests/KafkaFlow.IntegrationTests/ConsumerTest.cs
@@ -172,7 +172,7 @@ public class ConsumerTest
             .Without(m => m.Offset)
             .CreateMany(10).ToList();
 
-        messages.ForEach(m => producer.Produce(m.Id.ToString(), m, null, DeliveryHandler));
+        messages.ForEach(m => producer.Produce(m.Id.ToString(), m, null, report => DeliveryHandler(report, messages)));
 
         foreach (var message in messages)
         {
@@ -211,14 +211,12 @@ public class ConsumerTest
         }
 
         await serviceProviderHelper.StopBusAsync();
-        
-        return;
-        
-        void DeliveryHandler(DeliveryReport<byte[], byte[]> report)
-        {
-            var key = Encoding.UTF8.GetString(report.Message.Key);
-            var message = messages.First(m => m.Id.ToString() == key);
-            message.Offset = report.Offset;
-        }
+    }
+    
+    private static void DeliveryHandler(DeliveryReport<byte[], byte[]> report, List<OffsetTrackerMessage> messages)
+    {
+        var key = Encoding.UTF8.GetString(report.Message.Key);
+        var message = messages.First(m => m.Id.ToString() == key);
+        message.Offset = report.Offset;
     }
 }

--- a/tests/KafkaFlow.IntegrationTests/Core/Handlers/OffsetTrackerMessageHandler.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Handlers/OffsetTrackerMessageHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using KafkaFlow.IntegrationTests.Core.Messages;
+
+namespace KafkaFlow.IntegrationTests.Core.Handlers;
+
+internal class OffsetTrackerMessageHandler : IMessageHandler<OffsetTrackerMessage>
+{
+    public Task Handle(IMessageContext context, OffsetTrackerMessage message)
+    {
+        message.Offset = context.ConsumerContext.Offset;
+        MessageStorage.Add(message);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/KafkaFlow.IntegrationTests/Core/Messages/OffsetTrackerMessage.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Messages/OffsetTrackerMessage.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace KafkaFlow.IntegrationTests.Core.Messages;
+
+internal class OffsetTrackerMessage
+{
+    public Guid Id { get; set; }
+    public long Offset { get; set; }
+}

--- a/tests/KafkaFlow.IntegrationTests/Core/Producers/OffsetTrackerProducer.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/Producers/OffsetTrackerProducer.cs
@@ -1,0 +1,6 @@
+﻿namespace KafkaFlow.IntegrationTests.Core.Producers;
+
+public class OffsetTrackerProducer
+{
+
+}

--- a/tests/KafkaFlow.IntegrationTests/Core/ServiceProviderHelper.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/ServiceProviderHelper.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using KafkaFlow.Configuration;
+using KafkaFlow.IntegrationTests.Core.Producers;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Polly;
+
+namespace KafkaFlow.IntegrationTests.Core;
+
+public class ServiceProviderHelper
+{
+    private bool _isPartitionAssigned;
+
+    public async Task<IServiceProvider> GetServiceProviderAsync(
+        Action<IConsumerConfigurationBuilder> consumerConfiguration,
+        Action<IProducerConfigurationBuilder> producerConfiguration,
+        Action<IClusterConfigurationBuilder> builderConfiguration = null)
+    {
+        if (consumerConfiguration == null && producerConfiguration == null)
+        {
+            throw new ArgumentException("At least one of the configurations must be provided");
+        }
+        
+        var clusterBuilderAction = (HostBuilderContext context, IClusterConfigurationBuilder cluster) =>
+        {
+            cluster.WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(';'));
+            
+            if (consumerConfiguration != null)
+            {
+                cluster.AddConsumer(builder =>
+                {
+                    consumerConfiguration(builder);
+                    builder
+                        .WithBufferSize(100)
+                        .WithWorkersCount(10)
+                        .WithPartitionsAssignedHandler((_, _) =>
+                        {
+                            _isPartitionAssigned = true;
+                        })
+                        .AddMiddlewares(middlewares => middlewares.AddDeserializer<JsonCoreDeserializer>());
+                });
+            }
+            
+            if (producerConfiguration != null)
+            {
+                cluster.AddProducer<JsonProducer>(producerConfiguration);
+            }
+        };
+
+        clusterBuilderAction += (_, cluster) =>
+        {
+            builderConfiguration?.Invoke(cluster);
+        };
+
+        var builder = Host
+            .CreateDefaultBuilder()
+            .ConfigureAppConfiguration(
+                (_, config) =>
+                {
+                    config
+                        .SetBasePath(Directory.GetCurrentDirectory())
+                        .AddJsonFile(
+                            "conf/appsettings.json",
+                            false,
+                            true)
+                        .AddEnvironmentVariables();
+                })
+            .ConfigureServices((context, services) =>
+                services.AddKafka(
+                    kafka => kafka
+                        .UseLogHandler<TraceLogHandler>()
+                        .AddCluster(cluster => { clusterBuilderAction.Invoke(context, cluster); })))
+            .UseDefaultServiceProvider(
+                (_, options) =>
+                {
+                    options.ValidateScopes = true;
+                    options.ValidateOnBuild = true;
+                });
+
+        var host = builder.Build();
+        var bus = host.Services.CreateKafkaBus();
+        await bus.StartAsync();
+        
+        await WaitForPartitionAssignmentAsync();
+
+        return host.Services;
+    }
+    
+    private async Task WaitForPartitionAssignmentAsync()
+    {
+        await Policy
+            .HandleResult<bool>(isAvailable => !isAvailable)
+            .WaitAndRetryAsync(Enumerable.Range(0, 6).Select(i => TimeSpan.FromSeconds(Math.Pow(i, 2))))
+            .ExecuteAsync(() => Task.FromResult(_isPartitionAssigned));
+    }
+}

--- a/website/docs/guides/consumers/add-consumers.md
+++ b/website/docs/guides/consumers/add-consumers.md
@@ -79,6 +79,27 @@ services.AddKafka(kafka => kafka
 );
 ```
 
+## Manual Partition Offset Assignment
+
+The client application can specify the offsets to start consuming from per partition for topics manually using the `ManualAssignPartitionOffsets()` method.
+
+
+```csharp
+using KafkaFlow;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddKafka(kafka => kafka
+    .AddCluster(cluster => cluster
+        .WithBrokers(new[] { "localhost:9092" })
+        .AddConsumer(consumer => consumer
+            .ManualAssignPartitionOffsets("topic-name",  new Dictionary<int, long> { { 0, 100 }, { 1, 120 } })
+            ...
+        )
+    )
+);
+```
+
 ## Offset Strategy
 
 You can configure the Offset Strategy for a consumer group in case the Consumer Group has no offset stored in Kafka. 


### PR DESCRIPTION
# Description

Implemented `ManualAssignPartitionOffsets` to allow consumers to start consuming from a specified offset.

## How Has This Been Tested?

I've added `ManualAssignPartitionOffsetsTest` into the integration test suite. This uses the bootstrapped service provider to place 10 messages into a topic initially. It then creates a new service provider with a consumer to start at offset 5. The test verifies that the consumer only consumes messages at offsets 5 - 9. 
I've added a ServiceProviderHelper to aid in the creation of the provider and refactored the GlobalEventTests to reduce code duplication.

Manual tests to verify consumers are starting from the specified offsets.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

## Notes

I had to convert SaslOauthbearerMethod.cs to a file-scoped namespace or the solution would not build. Happy to revert this if needed.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
