### PR TITLE
Add configs dictionary to topic configuration

### DIFF
--- a/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IClusterConfigurationBuilder.cs
@@ -82,4 +82,18 @@ public interface IClusterConfigurationBuilder
         string topicName,
         int numberOfPartitions = -1,
         short replicationFactor = -1);
+
+    /// <summary>
+    /// Adds a Topic to the Cluster
+    /// </summary>
+    /// <param name="configs">Topic configurations.</param>
+    /// <param name="topicName">The topic name</param>
+    /// <param name="numberOfPartitions">The number of Topic partitions. Default is to use the cluster-defined partitions.</param>
+    /// <param name="replicationFactor">The Topic replication factor. Default is to use the cluster-defined replication factor.</param>
+    /// <returns></returns>
+    IClusterConfigurationBuilder CreateTopicIfNotExists(
+        Dictionary<string, string> configs,
+        string topicName,
+        int numberOfPartitions = -1,
+        short replicationFactor = -1);
 }

--- a/src/KafkaFlow/Clusters/ClusterManager.cs
+++ b/src/KafkaFlow/Clusters/ClusterManager.cs
@@ -119,6 +119,7 @@ internal class ClusterManager : IClusterManager, IDisposable
                 .Select(
                     topicConfiguration => new TopicSpecification
                     {
+                        Configs = topicConfiguration.Configs,
                         Name = topicConfiguration.Name,
                         ReplicationFactor = topicConfiguration.Replicas,
                         NumPartitions = topicConfiguration.Partitions,

--- a/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ClusterConfigurationBuilder.cs
@@ -116,4 +116,14 @@ internal class ClusterConfigurationBuilder : IClusterConfigurationBuilder
         _topicsToCreateIfNotExist.Add(new TopicConfiguration(topicName, numberOfPartitions, replicationFactor));
         return this;
     }
+
+    public IClusterConfigurationBuilder CreateTopicIfNotExists(
+        Dictionary<string, string> configs,
+        string topicName,
+        int numberOfPartitions = -1,
+        short replicationFactor = -1)
+    {
+        _topicsToCreateIfNotExist.Add(new TopicConfiguration(configs, topicName, numberOfPartitions, replicationFactor));
+        return this;
+    }
 }

--- a/src/KafkaFlow/Configuration/TopicConfiguration.cs
+++ b/src/KafkaFlow/Configuration/TopicConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace KafkaFlow.Configuration;
 
 /// <summary>
@@ -13,10 +15,32 @@ public class TopicConfiguration
     /// <param name="replicas">Replication factor for the topic</param>
     public TopicConfiguration(string name, int partitions, short replicas)
     {
+        this.Configs = new Dictionary<string, string>();
         this.Name = name;
         this.Partitions = partitions;
         this.Replicas = replicas;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TopicConfiguration"/> class.
+    /// </summary>
+    /// <param name="configs">Topic configurations.</param>
+    /// <param name="name">The topic name</param>
+    /// <param name="partitions">The number of partitions for the topic</param>
+    /// <param name="replicas">Replication factor for the topic</param>
+    public TopicConfiguration(Dictionary<string, string> configs, string name, int partitions, short replicas)
+    {
+        this.Configs = configs;
+        this.Name = name;
+        this.Partitions = partitions;
+        this.Replicas = replicas;
+    }
+
+    /// <summary>
+    /// Gets the configuration used to create the new topic.
+    /// <see href="https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html">Configuration Reference</see>
+    /// </summary>
+    public Dictionary<string, string> Configs { get; }
 
     /// <summary>
     /// Gets the Topic Name

--- a/tests/KafkaFlow.IntegrationTests/Core/AdminClient.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/AdminClient.cs
@@ -1,0 +1,13 @@
+﻿using Confluent.Kafka;
+
+namespace KafkaFlow.IntegrationTests.Core;
+
+public class AdminClient
+{
+    public IAdminClient Client { get; }
+    
+    public AdminClient(string bootstrapServers)
+    {
+        Client = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
+    }
+}

--- a/tests/KafkaFlow.IntegrationTests/Core/ServiceProviderHelper.cs
+++ b/tests/KafkaFlow.IntegrationTests/Core/ServiceProviderHelper.cs
@@ -28,7 +28,7 @@ public class ServiceProviderHelper
 
         var clusterBuilderAction = (HostBuilderContext context, IClusterConfigurationBuilder cluster) =>
         {
-            cluster.WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(';'));
+            cluster.WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(','));
 
             if (consumerConfiguration != null)
             {

--- a/tests/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
+++ b/tests/KafkaFlow.IntegrationTests/OpenTelemetryTests.cs
@@ -252,7 +252,7 @@ public class OpenTelemetryTests
                         .UseLogHandler<TraceLogHandler>()
                         .AddCluster(
                             cluster => cluster
-                                .WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(';'))
+                                .WithBrokers(context.Configuration.GetValue<string>("Kafka:Brokers").Split(','))
                                 .CreateTopicIfNotExists(_topicName, 1, 1)
                                 .AddProducer<GzipProducer>(
                                     producer => producer

--- a/tests/KafkaFlow.IntegrationTests/TopicConfigurationTest.cs
+++ b/tests/KafkaFlow.IntegrationTests/TopicConfigurationTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using KafkaFlow.IntegrationTests.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KafkaFlow.IntegrationTests;
+
+[TestClass]
+public class TopicConfigurationTest
+{
+    private IAdminClient _adminClient;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _adminClient = Bootstrapper.GetServiceProvider().GetRequiredService<AdminClient>().Client;
+    }
+    
+    [TestMethod]
+    public async Task DefaultConfigurationTest()
+    {
+        var configResource = new ConfigResource
+        {
+            Type = ResourceType.Topic,
+            Name = Bootstrapper.DefaultParamsTopicName
+        };
+        
+        var configs = await _adminClient.DescribeConfigsAsync(new[] { configResource });
+        var config = configs.First();
+        
+        foreach (var key in config.Entries.Keys)
+        {
+            Assert.IsTrue(config.Entries[key].IsDefault);
+        }
+    }
+    
+    [TestMethod]
+    public async Task ModifiedConfigurationTest()
+    {
+        var configResource = new ConfigResource
+        {
+            Type = ResourceType.Topic,
+            Name = Bootstrapper.ModifiedConfigTopicName
+        };
+        
+        var configs = await _adminClient.DescribeConfigsAsync(new[] { configResource });
+        var config = configs.First();
+        foreach (var key in config.Entries.Keys)
+        {
+            if (Bootstrapper.s_modifiedConfigValues.TryGetValue(key, out var expectedValue))
+            {
+                Assert.IsFalse(config.Entries[key].IsDefault);
+                Assert.AreEqual(expectedValue, config.Entries[key].Value);
+            }
+            else
+            {
+                Assert.IsTrue(config.Entries[key].IsDefault);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Extends the `TopicSpecification` class to add the Configs dictionary. This allows users to pass topic config values when creating new topics.